### PR TITLE
Allow ProcessZoneEvent to also handle InstanceTypes

### DIFF
--- a/ItemRack/ItemRackEvents.lua
+++ b/ItemRack/ItemRackEvents.lua
@@ -444,11 +444,12 @@ function ItemRack.ProcessZoneEvent()
 	local currentZone = GetRealZoneText()
 	local currentSubZone = GetSubZoneText()
 	local setToEquip, setToUnequip, setname
+	local _,instanceType = IsInInstance()
 
 	for eventName in pairs(enabled) do
 		if events[eventName].Type=="Zone" then
 			setname = ItemRackUser.Events.Set[eventName]
-			local inZone = events[eventName].Zones[currentZone] or events[eventName].Zones[currentSubZone]
+			local inZone = events[eventName].Zones[currentZone] or events[eventName].Zones[currentSubZone] or events[eventName].Zones[instanceType]
 			
 			if inZone then
 				if not events[eventName].Active then


### PR DESCRIPTION
This change will allow ProcessZoneEvent to check if the given zone name is an instance type if a matching zone name is not found.  This is similar to how the NotInPVP and NotInPVE flags work behind the scenes, but will give users more flexibility when entering 'zone names' so they can just enter an instance type instead of the name of every zone matching that type.  Ideally this would probably would be better suited to have it's own dropdown just for instance types instead of piggybacking off of the "Zone" dropdown in the Events tab, but considering the minor coding change needed for it and the probably niche use, I figured that piggybacking would be okay, but I can understand if you disagree.

This will work for all instance types: "none" "party" "raid" "pvp" and "arena"