### PR TITLE
Fix key bindings when used in combat

### DIFF
--- a/ItemRack/ItemRack.lua
+++ b/ItemRack/ItemRack.lua
@@ -3531,6 +3531,7 @@ function ItemRack.SetSetBindings()
 			button = _G[buttonName] or CreateFrame("Button",buttonName,nil,"SecureActionButtonTemplate")
 
 			button:SetAttribute("type","macro")
+			button:SetAttribute("useOnKeyDown", false)
 			local macrotext = ""
 			for slot = 16, 18 do
 				local itemID = ItemRackUser.Sets[i].equip[slot]


### PR DESCRIPTION
This fixes an issue with the recent World of Warcraft Era 1.15.9 Update. The keybindings (e.g. swapping to a shield in offhand via bound mouse or keyboard button) stopped working in combat. There was no lua issue or similar, it just "ignored" the click. Out of combat everything worked fine.
While playing around with the key binding arguments, I came across `useOnKeyDown` and it seems that if this attribute is *not* set, it will not work in combat.
Maybe this attribute is now mandatory for `SecureActionButton`?

I just tested this on WoW Classic Era 1.15.9 and it works fine now, I do not know if this also works on WoW Classic TBC, this probably needs to be tested.